### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -623,7 +623,7 @@ class Envato_WP_Toolkit {
   public function _field_skip_theme_backup() {
     $options = get_option( EWPT_PLUGIN_SLUG );
     $field_value = isset( $options['skip_theme_backup'] ) ? true : false;
-    echo '<input type="checkbox" class="regular-text" name="' . EWPT_PLUGIN_SLUG . '[skip_theme_backup]" value="1" ' . checked( $field_value, 1, false ) . ' />';
+    echo '<input type="checkbox" name="' . EWPT_PLUGIN_SLUG . '[skip_theme_backup]" value="1" ' . checked( $field_value, 1, false ) . ' />';
   }
   
   /**


### PR DESCRIPTION
Issue:
Checkbox for Skip Theme Backup field is rendering at 100% width on Safari instead of normal 1em checkbox width.

Solution:
Removed class="regular-text" from checkbox field output on line 626.
