### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -116,8 +116,12 @@ class Envato_WP_Toolkit {
    */
   protected function _includes() {
     /* load required files */
-    foreach ( array( 'class-wp-upgrader', 'class-envato-backup' ) as $file )
-      require_once( EWPT_PLUGIN_DIR . 'includes/' . $file . '.php' );
+    if ( ! class_exists( 'Envato_Theme_Upgrader' ) ) {
+      require_once( EWPT_PLUGIN_DIR . 'includes/class-wp-upgrader.php' );
+    }
+    if ( ! class_exists( 'Envato_Backup' ) ) {
+      require_once( EWPT_PLUGIN_DIR . 'includes/class-envato-backup.php' );
+    }
     if ( ! class_exists( 'Envato_Protected_API' ) ) {
       require_once( EWPT_PLUGIN_DIR . 'includes/class-envato-api.php' );
     }


### PR DESCRIPTION
Hi,

We need this update for "Envato Wordpress Toolkit Library" Envato_Backup class conflict. Toolkit Library not using a backup, i am planing to use Envato_Backup class. and here we need to class_exists for avoid conflict. You know backup is importand before theme update. A minor pull request :smiley: 