### PR TITLE
Wordpress version bump to Wordpress 4.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: envato, valendesigns
 Tags: install, update, api, envato, theme, upgrade
 Requires at least: 3.7
-Tested up to: 4.3-beta1
+Tested up to: 4.5
 Stable tag: 1.7.3
 
 WordPress toolkit for Envato Marketplace hosted items. Currently supports the following theme functionality: install, upgrade, & backups during upgrade.


### PR DESCRIPTION
Tested the current version with Wordpress 4.5 and it worked fine.
So, I think version should be bumped in readme