### PR TITLE
Version 1.8.0 - Deprecation notice 

### DIFF
--- a/includes/class-envato-api.php
+++ b/includes/class-envato-api.php
@@ -22,7 +22,7 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public $user_name;
-    
+
     /**
      * The buyer's API Key
      *
@@ -32,7 +32,7 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public $api_key;
-    
+
     /**
      * The default API URL
      *
@@ -42,7 +42,7 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     protected $public_url = 'https://marketplace.envato.com/api/edge/set.json';
-    
+
     /**
      * Error messages
      *
@@ -52,7 +52,7 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public $errors = array( 'errors' => '' );
-    
+
     /**
      * Class contructor method
      *
@@ -64,20 +64,20 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public function __construct( $user_name = '', $api_key = '' ) {
-    
+
       if ( $user_name == '' ) {
         $this->set_error( 'user_name', __( 'Please enter your Envato Marketplace Username.', 'envato-wordpress-toolkit' ) );
       }
-        
+
       if ( $api_key == '' ) {
         $this->set_error( 'api_key', __( 'Please enter your Envato Marketplace API Key.', 'envato-wordpress-toolkit' ) );
       }
-        
+
       $this->user_name  = $user_name;
       $this->api_key    = $api_key;
-      
+
     }
-    
+
     /**
      * Get private user data.
      *
@@ -91,58 +91,58 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @access    public
      * @since     1.0
      * @updated   1.3
-     */ 
-    public function private_user_data( $set = '', $user_name = '', $set_data = '', $allow_cache = false, $timeout = 300 ) { 
-      
+     */
+    public function private_user_data( $set = '', $user_name = '', $set_data = '', $allow_cache = false, $timeout = 300 ) {
+
       if ( $set == '' ) {
         $this->set_error( 'set', __( 'The API "set" is a required parameter.', 'envato-wordpress-toolkit' ) );
       }
-        
+
       if ( $user_name == '' ) {
         $user_name = $this->user_name;
       }
-      
+
       if ( $user_name == '' ) {
         $this->set_error( 'user_name', __( 'Please enter your Envato Marketplace Username.', 'envato-wordpress-toolkit' ) );
       }
-        
+
       if ( $set_data !== '' ) {
         $set_data = ":$set_data";
       }
-      
+
       if ( $errors = $this->api_errors() ) {
         return $errors;
       }
-        
+
       $url = "https://marketplace.envato.com/api/edge/$user_name/$this->api_key/$set$set_data.json";
-      
+
       /* set transient ID for later */
       $transient = substr( md5( $user_name . '_' . $set . $set_data ), 0, 16 );
-      
+
       if ( $allow_cache ) {
         $cache_results = $this->set_cache( $transient, $url, $timeout );
         $results = $cache_results;
       } else {
         $results = $this->remote_request( $url );
       }
-      
+
       if ( isset( $results->error ) ) {
         $this->set_error( 'error_' . $set, $results->error );
       }
-      
+
       if ( $errors = $this->api_errors() ) {
         $this->clear_cache( $transient );
         return $errors;
       }
-      
+
       if ( isset( $results->$set ) ) {
         return $results->$set;
       }
-      
+
       return false;
-      
+
     }
-    
+
     /**
      * Used to list purchased themes.
      *
@@ -155,21 +155,21 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @updated   1.3
      */
     public function wp_list_themes( $allow_cache = true, $timeout = 300 ) {
-      
+
       if ( $this->user_name == '' ) {
         $this->set_error( 'user_name', __( 'Please enter your Envato Marketplace Username.', 'envato-wordpress-toolkit' ) );
       }
-      
+
       $themes = $this->private_user_data( 'wp-list-themes', $this->user_name, '', $allow_cache, $timeout );
-      
+
       if ( $errors = $this->api_errors() ) {
         return $errors;
       }
-      
+
       return $themes;
-      
+
     }
-    
+
     /**
      * Used to download a purchased item.
      *
@@ -180,28 +180,28 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      *
      * @access    public
      * @since     1.0
-     */ 
+     */
     public function wp_download( $item_id ) {
-      
+
       if ( ! isset( $item_id ) ) {
         $this->set_error( 'item_id', __( 'The Envato Marketplace "item ID" is a required parameter.', 'envato-wordpress-toolkit' ) );
       }
-        
+
       $download = $this->private_user_data( 'wp-download', $this->user_name, $item_id );
-      
+
       if ( $errors = $this->api_errors() ) {
         return $errors;
       } else if ( isset( $download->url ) ) {
         return $download->url;
       }
-      
+
       return false;
     }
-    
+
     /**
      * Retrieve the details for a specific marketplace item.
      *
-     * @param     string      $item_id The id of the item you need information for. 
+     * @param     string      $item_id The id of the item you need information for.
      * @return    object      Details for the given item.
      *
      * @access    public
@@ -209,36 +209,36 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @updated   1.3
      */
     public function item_details( $item_id, $allow_cache = true, $timeout = 300 ) {
-      
+
       $url = preg_replace( '/set/i', 'item:' . $item_id, $this->public_url );
-      
+
       /* set transient ID for later */
       $transient = substr( md5( 'item_' . $item_id ), 0, 16 );
-        
+
       if ( $allow_cache ) {
         $cache_results = $this->set_cache( $transient, $url, $timeout );
         $results = $cache_results;
       } else {
         $results = $this->remote_request( $url );
       }
-      
+
       if ( isset( $results->error ) ) {
         $this->set_error( 'error_item_' . $item_id, $results->error );
       }
-      
+
       if ( $errors = $this->api_errors() ) {
         $this->clear_cache( $transient );
         return $errors;
       }
-        
+
       if ( isset( $results->item ) ) {
         return $results->item;
       }
-      
+
       return false;
-      
+
     }
-    
+
     /**
      * Set cache with the Transients API.
      *
@@ -251,35 +251,35 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      *
      * @access    public
      * @since     1.3
-     */ 
+     */
     public function set_cache( $transient = '', $url = '', $timeout = 300 ) {
-    
+
       if ( $transient == '' || $url == '' ) {
         return false;
       }
-      
+
       /* keep the code below cleaner */
       $transient = $this->validate_transient( $transient );
       $transient_timeout = '_transient_timeout_' . $transient;
-      
+
       /* set original cache before we destroy it */
       $old_cache = get_option( $transient_timeout ) < time() ? get_option( $transient ) : '';
-      
+
       /* look for a cached result and return if exists */
       if ( false !== $results = get_transient( $transient ) ) {
         return $results;
       }
-      
+
       /* create the cache and allow filtering before it's saved */
       if ( $results = apply_filters( 'envato_api_set_cache', $this->remote_request( $url ), $transient ) ) {
         set_transient( $transient, $results, $timeout );
         return $results;
       }
-      
+
       return false;
-      
+
     }
-    
+
     /**
      * Clear cache with the Transients API.
      *
@@ -290,13 +290,13 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      *
      * @access    public
      * @since     1.3
-     */ 
+     */
     public function clear_cache( $transient = '' ) {
-    
+
       delete_transient( $transient );
-      
+
     }
-    
+
     /**
      * Helper function to validate transient ID's.
      *
@@ -307,11 +307,11 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.3
      */
     public function validate_transient( $id = '' ) {
-  
+
       return preg_replace( '/[^A-Za-z0-9\_\-]/i', '', str_replace( ':', '_', $id ) );
-      
+
     }
-    
+
     /**
      * Helper function to set error messages.
      *
@@ -323,11 +323,11 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public function set_error( $id, $error ) {
-    
+
       $this->errors['errors'][$id] = $error;
-      
+
     }
-    
+
     /**
      * Helper function to return the set errors.
      *
@@ -337,13 +337,13 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public function api_errors() {
-    
+
       if ( ! empty( $this->errors['errors'] ) ) {
         return $this->errors['errors'];
       }
-      
+
     }
-    
+
     /**
      * Helper function to query the marketplace API via wp_remote_request.
      *
@@ -354,15 +354,15 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     protected function remote_request( $url ) {
-    
+
       if ( empty( $url ) ) {
         return false;
       }
 
       $args = array(
-        'headers'    => array( 'Accept-Encoding' => '' ), 
+        'headers'    => array( 'Accept-Encoding' => '' ),
         'timeout'    => 30,
-        'user-agent' => 'Toolkit/1.7.3',
+        'user-agent' => 'Toolkit/1.7.4',
       );
 
       $options = get_option( EWPT_PLUGIN_SLUG );
@@ -371,27 +371,27 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
       }
 
       $request = wp_safe_remote_request( $url, $args );
-  
+
       if ( is_wp_error( $request ) ) {
       	echo $request->get_error_message();
       	return false;
       }
-  
+
       $data = json_decode( $request['body'] );
-      
+
       if ( $request['response']['code'] == 200 ) {
         return $data;
       } else {
         $this->set_error( 'http_code', $request['response']['code'] );
       }
-        
+
       if ( isset( $data->error ) ) {
-        $this->set_error( 'api_error', $data->error ); 
+        $this->set_error( 'api_error', $data->error );
       }
-      
+
       return false;
     }
-    
+
     /**
      * Helper function to print arrays to the screen ofr testing.
      *
@@ -402,11 +402,11 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
      * @since     1.0
      */
     public function pretty_print( $array ) {
-    
+
       echo '<pre>';
       print_r( $array );
       echo '</pre>';
-      
+
     }
   }
 

--- a/includes/class-envato-api.php
+++ b/includes/class-envato-api.php
@@ -362,7 +362,7 @@ if ( ! class_exists( 'Envato_Protected_API' ) ) {
       $args = array(
         'headers'    => array( 'Accept-Encoding' => '' ),
         'timeout'    => 30,
-        'user-agent' => 'Toolkit/1.7.4',
+        'user-agent' => 'Toolkit/1.8.0',
       );
 
       $options = get_option( EWPT_PLUGIN_SLUG );

--- a/index.php
+++ b/index.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Plugin Name: Envato WordPress Toolkit
+ * Plugin Name: Envato WordPress Toolkit (Deprecated)
  * Plugin URI: https://github.com/envato/envato-wordpress-toolkit
  * Description: WordPress toolkit for Envato Marketplace hosted items. Currently supports the following theme functionality: install, upgrade, & backups during upgrade.
- * Version: 1.7.3
+ * Version: 1.7.4
  * Author: Envato
  * Author URI: http://envato.com
  */
 if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
 
   class Envato_WP_Toolkit {
-    
+
     /**
      * The Envato Protected API object
      *
@@ -20,7 +20,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @var       object
      */
     protected $protected_api;
-    
+
     /**
      * Nonce for AJAX notifications
      *
@@ -30,7 +30,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @var       string
      */
     protected $ajax_notification_nonce;
-    
+
     /**
      * PHP5 constructor method.
      *
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       $this->_includes();
       $this->_hooks();
     }
-    
+
     /**
      * Defines the constants for use within the plugin.
      *
@@ -62,52 +62,52 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       /**
        * Plugin Version
        */
-      define( 'EWPT_PLUGIN_VER', '1.7.3' );
-      
+      define( 'EWPT_PLUGIN_VER', '1.7.4' );
+
       /**
        * Plugin Name
        */
       define( 'EWPT_PLUGIN_NAME', __( 'Envato WordPress Toolkit', 'envato-wordpress-toolkit' ) );
-      
+
       /**
        * Plugin Slug
        */
       define( 'EWPT_PLUGIN_SLUG', 'envato-wordpress-toolkit' );
-      
+
       /**
        * Maximum request time
        */
       define( 'EWPT_PLUGIN_MAX_EXECUTION_TIME' , 60 * 5 );
-      
+
       /**
        * Plugin Directory Path
        */
       define( 'EWPT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-      
+
       /**
        * Plugin Directory URL
        */
       define( 'EWPT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-      
+
       /**
        * Theme Backup Directory Path
        */
       define( 'EWPT_BACKUP_DIR', WP_CONTENT_DIR . '/envato-backups/' );
-  
+
       /**
        * Theme Backup Directory URL
        */
       define( 'EWPT_BACKUP_URL', WP_CONTENT_URL . '/envato-backups/' );
-      
+
       /**
        * Create a key for the .htaccess secure download link.
        *
        * @uses    NONCE_KEY     Defined in the WP root config.php
        */
       define( 'EWPT_SECURE_KEY', md5( NONCE_KEY ) );
-      
+
     }
-    
+
     /**
      * Include required files
      *
@@ -132,7 +132,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
         require_once( EWPT_PLUGIN_DIR . 'includes/class-github-updater.php' );
       }
     }
-    
+
     /**
      * Setup the default filters and actions
      *
@@ -152,38 +152,51 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       } else {
         add_action( 'admin_menu', array( $this, '_envato_menu' ), 101 );
       }
-      
+
       /**
        * Menu Icon CSS
        */
       add_action( 'admin_head', array( $this, '_menu_icon' ) );
-      
+
       /**
        * Load text domain
        */
       add_action( 'plugins_loaded', array( $this, '_load_textdomain' ) );
-      
+
       /**
        * Create AJAX nonce
        */
       add_action( 'init', array( $this, '_ajax_notification_nonce' ) );
-      
+
       /**
-       * loaded during admin init 
+       * loaded during admin init
        */
       add_action( 'admin_init', array( $this, '_admin_init' ) );
-  
+
       /**
-       * change link URL & text after install & upgrade 
+       * change link URL & text after install & upgrade
        */
       add_filter( 'install_theme_complete_actions', array( $this, '_complete_actions' ), 10, 1 );
       add_filter( 'update_theme_complete_actions', array( $this, '_complete_actions' ), 10, 1 );
       add_filter( 'http_request_args', array( $this , '_http_request_args' ), 10, 1 );
-  
+
       add_action( 'wp_ajax_hide_admin_notification', array( $this, '_hide_admin_notification' ) );
-  
+
+	    add_action( 'admin_notices', array( $this, '_deprecation_notice' ) );
+
     }
-    
+
+	  /**
+	   * Adds the deprecation admin notice.
+	   *
+	   * @since 1.7.4
+	   */
+    public function _deprecation_notice(){
+	    $class = 'notice notice-error';
+	    $message = __( 'Warning: The Envato Toolkit plugin is no longer supported and will stop functioning very shortly. Please delete the Envato Toolkit plugin and install the Envato Market plugin.', 'sample-text-domain' );
+
+	    printf( '<div class="%1$s"><p>%2$s <a href="https://envato.com/market-plugin/upgrading/" target="_blank">Click here for more details.</a></p></div>', esc_attr( $class ), esc_html( $message ) );
+    }
     /**
      * Loads the text domain.
      *
@@ -195,9 +208,9 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
     public function _load_textdomain() {
 
       load_plugin_textdomain( 'envato-wordpress-toolkit', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-      
+
     }
-      
+
     /**
      * Create a nonce for AJAX notifications
      *
@@ -209,13 +222,13 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    void
      */
     public function _ajax_notification_nonce() {
-      
+
       /* only if in the admin area */
       if ( is_admin() )
         $this->ajax_notification_nonce = wp_create_nonce( 'ajax-notification-nonce' );
-        
+
     }
-    
+
     /**
      * Adds the Envato menu item
      *
@@ -225,18 +238,18 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    void
      */
     public function _envato_menu() {
-      
+
       /**
        * Stop Mojo Marketplace from tracking your movements!
        */
       remove_action( 'admin_footer', 'mm_ux_log', 9 );
-      
-      $menu_page = add_menu_page( EWPT_PLUGIN_NAME, __( 'Envato Toolkit', 'envato-wordpress-toolkit' ), 'manage_options', EWPT_PLUGIN_SLUG, array( $this, '_envato_menu_page' ), null, 58 );
-      
+
+      $menu_page = add_menu_page( EWPT_PLUGIN_NAME, __( 'Envato Toolkit', 'envato-wordpress-toolkit' ) .' <span class="update-plugins count-1"><span class="plugin-count">!</span></span>', 'manage_options', EWPT_PLUGIN_SLUG, array( $this, '_envato_menu_page' ), null, 58 );
+
       add_action('admin_print_scripts-' . $menu_page, array( $this, '_envato_load_scripts' ) );
       add_action('admin_print_styles-' . $menu_page, array( $this, '_envato_load_styles' ) );
     }
-    
+
     /**
      * Menu Font Icon CSS
      *
@@ -249,11 +262,11 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      */
     public function _menu_icon() {
       global $wp_version;
-      
+
       $wp_38plus = version_compare( $wp_version, '3.8', '>=' ) ? true : false;
       $fontsize = $wp_38plus ? '20px' : '16px';
       $wp_38minus = '';
-      
+
       if ( ! $wp_38plus ) {
         $wp_38minus = '
         #adminmenu .toplevel_page_envato-wordpress-toolkit .menu-icon-generic div.wp-menu-image {
@@ -263,7 +276,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
           padding-left: 6px;
         }';
       }
-    
+
       echo '
       <style>
         @font-face {
@@ -293,7 +306,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       </style>
       ';
     }
-    
+
     /**
      * Loads the scripts for the plugin
      *
@@ -306,7 +319,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       wp_enqueue_script( 'theme-preview' );
       wp_enqueue_script( 'ajax-notification', EWPT_PLUGIN_URL . 'assets/js/ajax-notification.js', false, EWPT_PLUGIN_VER );
     }
-    
+
     /**
      * Loads the styles for the plugin
      *
@@ -318,7 +331,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
     public function _envato_load_styles() {
       wp_enqueue_style( 'envato-wp-updater', EWPT_PLUGIN_URL . 'assets/css/style.css', false, EWPT_PLUGIN_VER, 'all' );
     }
-    
+
     /**
      * Envato Updater HTML
      *
@@ -326,17 +339,17 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      *
      * @access    private
      * @since     1.0
-     * @updated   1.4 
+     * @updated   1.4
      *
      * @return    string    Returns the verification form & themes list
      */
     public function _envato_menu_page() {
       if ( ! current_user_can( 'manage_options' ) )
         wp_die( __( 'You do not have sufficient permissions to access this page.', 'envato-wordpress-toolkit' ) );
-      
+
       /* read in existing API value from database */
       $options = get_option( EWPT_PLUGIN_SLUG );
-  
+
       /* display environment errors */
       if ( ! empty( $options['env_errors'] ) ) {
         foreach ( $options['env_errors'] as $k => $v ) {
@@ -345,15 +358,15 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
           }
         }
       }
-  
+
       $user_name = ( isset( $options['user_name'] ) ) ? $options['user_name'] : '';
       $api_key = ( isset( $options['api_key'] ) ) ? $options['api_key'] : '';
-      
+
       $this->protected_api = new Envato_Protected_API( $user_name, $api_key );
-      
+
       /* get purchased marketplace themes */
       $themes = $this->protected_api->wp_list_themes();
-      
+
       /* display API errors */
       if ( $errors = $this->protected_api->api_errors() ) {
         foreach( $errors as $k => $v ) {
@@ -361,14 +374,14 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
             echo '<div class="error below-h2"><p>' . $v . '</p></div>';
         }
       }
-      
+
       /* display update messages */
       if ( empty( $errors ) ) {
         echo ( isset( $_GET[ 'settings-updated' ] ) ) ? '<div class="updated below-h2"><p><strong>' . __( 'User Settings Updated.', 'envato-wordpress-toolkit' ) . '</strong></p></div>' : '';
         echo ( isset( $_GET[ 'activated' ] ) ) ? '<div class="updated below-h2"><p><strong>' . __( 'Theme Activated.', 'envato-wordpress-toolkit' ) . '</strong></p></div>' : '';
         echo ( isset( $_GET[ 'deleted' ] ) ) ? '<div class="updated below-h2"><p><strong>' . __( 'Theme Deleted.', 'envato-wordpress-toolkit' ) . '</strong></p></div>' : '';
       }
-  
+
       /* execute theme actions */
       if ( isset( $_GET['action'] ) && isset( $_GET['theme'] ) ) {
         if ( 'install-theme' == $_GET['action'] && is_array( $themes ) ) {
@@ -378,23 +391,23 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
         }
       /* display normal views */
       } else {
-  
+
         /* no errors & themes are available */
         if ( empty( $errors ) && count( $themes ) > 0 ) {
-        
+
           /* get WP installed themes */
           if ( function_exists( 'wp_get_themes' ) )
             $get_themes = wp_get_themes();
           else
             $get_themes = get_themes();
-        
+
           /* empty premium themes array */
           $premium_themes = array();
-          
+
           /* loop through the marketplace themes */
           if ( ! empty( $themes ) && is_array( $themes ) ) {
             foreach( $themes as $theme ) {
-              
+
               /* setup the defaults */
               $content = '';
               $installed = false;
@@ -410,12 +423,12 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
               $author = $theme->author_name;
               $parent_theme = '';
               $tags = '';
-              
+
               /* setup the item details */
               $item_details = $this->protected_api->item_details( $item_id );
-              
+
               if ( ! empty( $item_details ) ) {
-              
+
                 /* get installed theme information */
                 foreach( $get_themes as $k => $v ) {
                   if ( $get_themes[$k]['Title'] == $title && $get_themes[$k]['Author Name'] == $author && $template == '' ) {
@@ -436,7 +449,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                     continue;
                   }
                 }
-  
+
                 $has_update = ( $installed && version_compare( $version, $latest_version, '<' ) ) ? TRUE : FALSE;
                 $details_url = htmlspecialchars( add_query_arg( array( 'TB_iframe' => 'true', 'width' => 1024, 'height' => 800 ), $item_details->url ) );
                 $activate_url = wp_nonce_url( network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&action=activate&amp;template=' . urlencode( $template ) . '&amp;stylesheet=' . urlencode( $stylesheet ) ), 'switch-theme_' . $template );
@@ -446,39 +459,39 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                 $install_url = wp_nonce_url( network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&action=install-theme&theme=' . $item_id ), 'install-theme_' . $item_id );
                 $update_url = wp_nonce_url( network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&action=upgrade-theme&amp;theme=' . $stylesheet . '&amp;item_id=' . $item_id ), 'upgrade-theme_' . $stylesheet );
                 $update_onclick = 'onclick="if ( confirm(\'' . esc_js( __( "Updating this theme will lose any customizations you have made. 'Cancel' to stop, 'OK' to update.", 'envato-wordpress-toolkit' ) ) . '\') ) {return true;}return false;"';
-                
+
                 /* Theme Title message */
                 $content.= '<h3>' . $title . ' ' . $version . ' by ' . $author . '</h3>';
-                  
+
                 /* Theme Description */
                 if ( $description ) {
                   $content.= '<p class="description">' . $description . '</p>';
                 }
-                
+
                 /* Theme Backup URI */
                 $theme_backup_uri = $this->_get_theme_backup_uri( $template );
-                
+
                 /* Links list */
                 if ( $stylesheet && $template && $current_stylesheet !== $stylesheet ) {
-                  
+
                   $links[] = '<a href="' . $activate_url .  '" class="activatelink" title="' . esc_attr( sprintf( __( 'Activate &#8220;%s&#8221;', 'envato-wordpress-toolkit' ), $title ) ) . '">' . __( 'Activate', 'envato-wordpress-toolkit' ) . '</a> |';
-                  
+
                   $links[] = '<a href="' . network_admin_url( 'customize.php?theme=' . urlencode( $template ) ) . '&return=' . network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG ) . urlencode( '&' ) . 'tab=themes" class="load-customize hide-if-no-customize" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'envato-wordpress-toolkit' ), $title ) ) . '">' . __( 'Preview', 'envato-wordpress-toolkit' ) . '</a> <span class="hide-if-no-customize">|</span>';
-                  
+
                   $links[] = '<a href="' . $preview_url . '" class="thickbox thickbox-preview hide-if-customize" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'envato-wordpress-toolkit' ), $title ) ) . '">' . __( 'Preview', 'envato-wordpress-toolkit' ) . '</a> <span class="hide-if-customize">|</span>';
-                  
+
                   $links[] = '<a href="' . $delete_url . '" class="submitdelete deletion" title="' . esc_attr( sprintf( __( 'Delete &#8220;%s&#8221;', 'envato-wordpress-toolkit' ), $title ) ) . '" ' . $delete_onclick . '>' . __( 'Delete' ) . '</a> |';
-                  
+
                   $links[] = '<a href="' . $details_url . '" class="thickbox thickbox-preview" title="' . esc_attr( sprintf( __( 'View version %1$s details', 'envato-wordpress-toolkit' ), $latest_version ) ) . '">' . esc_attr( sprintf( __( 'View version %1$s details', 'envato-wordpress-toolkit' ), $latest_version ) ) . '</a> |';
-                  
+
                   if ( ! empty( $theme_backup_uri ) ) {
                     $links[] = '<a href="' . $theme_backup_uri . '" title="' . esc_attr( __( 'Download Backup', 'envato-wordpress-toolkit' ) ) . '">' . esc_attr( __( 'Download Backup', 'envato-wordpress-toolkit' ) ) . '</a> |';
                   }
-                  
+
                   $content.= '<div class="update-info">' . rtrim( implode( ' ', $links ), ' |' ) . '</div>';
-                  
+
                 }
-                
+
                 /**
                  * This ugly code lists the current theme options
                  * It was pulled from wp-admin/themes.php with minor tweaks
@@ -514,14 +527,14 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                 			}
                 		}
                 	}
-  	
+
                   if ( ! empty( $theme_backup_uri ) ) {
                     $options[] = '<a href="' . $theme_backup_uri . '" title="' . esc_attr( __( 'Download Backup', 'envato-wordpress-toolkit' ) ) . '">' . esc_attr( __( 'Download Backup', 'envato-wordpress-toolkit' ) ) . '</a>';
                   }
                   if ( ! empty( $options ) )
                     $content.= '<div class="update-info"><span>' . __( 'Options:', 'envato-wordpress-toolkit' ) . '</span> ' . implode( ' | ', $options ) . '</div>';
                 }
-                
+
                 /* Theme path information */
                 if ( current_user_can( 'edit_themes' ) && $installed ) {
                   if ( $parent_theme ) {
@@ -530,12 +543,12 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                      $content.= '<p>' . sprintf( __( 'All of this theme&#8217;s files are located in <code>%2$s</code>.', 'envato-wordpress-toolkit' ), $title, str_replace( WP_CONTENT_DIR, '', $template_dir ), str_replace( WP_CONTENT_DIR, '', $stylesheet_dir ) ) . '</p>';
                   }
                 }
-                
+
                 /* Tags list */
                 if ( $tags ) {
                   $content.= '<p>' . __( 'Tags: ' ). join( ', ', $tags ) . '</p>';
                 }
-                
+
                 /* Upgrade/Install message */
                 if ( $has_update ) {
                   if ( ! current_user_can( 'update_themes' ) ) {
@@ -550,7 +563,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                     $content.= sprintf( '<div class="updated below-h2"><p><strong>' . __( '%1$s has not been installed. <a href="%2$s" class="thickbox thickbox-preview" title="%1$s">View version %3$s details</a> or <a href="%4$s">install automatically</a>.', 'envato-wordpress-toolkit' ) . '</strong></p></div>', $title, $details_url, $latest_version, $install_url );
                   }
                 }
-                
+
                 /* put the HTML into a variable */
                 $list_item = '
                 <li>
@@ -561,17 +574,17 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                     ' . $content . '
                   </div>
                 </li>';
-                
+
                 $premium_themes[] = array(
                   'current_theme' => ( $current_stylesheet == $stylesheet ? true : false ),
                   'list_item' => $list_item
                 );
-  
+
               }
-              
+
             }
           }
-          
+
           /**
            * Loop through all the premium themes.
            * Separate out the current one, display it, & remove from array
@@ -586,7 +599,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                 unset( $premium_themes[$k] );
               }
             }
-            
+
             /* list current premium theme */
             if ( ! empty( $current_theme ) ) {
               $themes_output.= __( '<h3>Current Theme</h3>' );
@@ -594,7 +607,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
                 $themes_output.= $current_theme['list_item'];
               $themes_output.= '</ul>';
             }
-            
+
             /* list premium themes */
             $themes_output.= __( '<h3>Available Themes</h3>' );
             $themes_output.= '<ul class="ewpt-item-list">';
@@ -602,25 +615,25 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
               $themes_output.= $premium_themes[$k]['list_item'];
             $themes_output.= '</ul>';
           }
-            
+
         }
-        
+
         /* Get the current tab */
         $tab = isset( $_GET['tab'] ) ? $_GET['tab'] : 'settings';
-          
+
         /* Display Markup */
         echo '<div class="wrap">';
-          
+
           echo '<h2 class="nav-tab-wrapper">';
-            
+
             echo '<a class="nav-tab' . ( $tab == 'settings' ? ' nav-tab-active': '' ) . '" href="?page=envato-wordpress-toolkit&tab=settings">Settings</a>';
-            
+
           if ( isset( $themes_output ) ) {
             echo '<a class="nav-tab' . ( $tab == 'themes' ? ' nav-tab-active': '' ) . '" href="?page=envato-wordpress-toolkit&tab=themes">Themes</a>';
           }
-          
+
           echo '</h2>';
-          
+
           if ( $tab == 'settings' || ! isset( $themes_output ) ) {
             echo '
             <form name="verification_form" method="post" action="' . admin_url( 'options.php' ) . '" id="api-verification">';
@@ -633,17 +646,17 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
               </p>
             </form>';
           }
-          
+
           if ( $tab == 'themes' && isset( $themes_output ) ) {
-            
+
             echo $themes_output;
-            
+
           }
-          
-        echo '</div>';   
+
+        echo '</div>';
       }
     }
-  
+
     /**
      * Checks for updates to the plugin
      *
@@ -653,11 +666,11 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    void
      */
     protected function _admin_update_check() {
-  
+
       if ( class_exists( 'WP_GitHub_Updater' ) ) {
-  
+
         if ( is_admin() ) { // note the use of is_admin() to double check that this is happening in the admin
-  
+
           $config = array(
             'slug'                => plugin_basename( __FILE__ ),
             'plugin'              => plugin_basename( __FILE__ ),
@@ -669,15 +682,15 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
             'sslverify'           => true,
             'access_token'        => ''
           );
-  
+
           new WP_GitHub_Updater( $config );
-  
+
         }
-  
+
       }
-  
+
     }
-    
+
     /**
      * Runs code before the headers are sent
      *
@@ -718,7 +731,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       }
 
     }
-    
+
     /**
      * Registers the settings for the updater
      *
@@ -731,6 +744,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       $this->_admin_update_check();
       $this->_admin_init_before();
       register_setting( EWPT_PLUGIN_SLUG, EWPT_PLUGIN_SLUG );
+      add_settings_section( 'envato_toolkit_deprecation', __( 'Plugin Deprecation Notice', 'envato-wordpress-toolkit' ), array( $this, '_section_deprecation' ), EWPT_PLUGIN_SLUG );
       add_settings_section( 'user_account_info', __( 'User Account Information', 'envato-wordpress-toolkit' ), array( $this, '_section_user_account_info' ), EWPT_PLUGIN_SLUG );
       add_settings_field( 'user_name', __( 'Marketplace Username', 'envato-wordpress-toolkit' ), array( $this, '_field_user_name' ), EWPT_PLUGIN_SLUG, 'user_account_info' );
       add_settings_field( 'api_key', __( 'Secret API Key', 'envato-wordpress-toolkit' ), array( $this, '_field_api_key' ), EWPT_PLUGIN_SLUG, 'user_account_info' );
@@ -741,7 +755,22 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       add_settings_section( 'sslverify', __( 'SSL Verify', 'envato-wordpress-toolkit' ), array( $this, '_section_sslverify' ), EWPT_PLUGIN_SLUG );
       add_settings_field( 'deactivate_sslverify', __( 'Deactivate SSL Verify', 'envato-wordpress-toolkit' ), array( $this, '_field_deactivate_sslverify' ), EWPT_PLUGIN_SLUG, 'sslverify' );
     }
-    
+
+    /**
+     * Deprecation notice on settings page.
+     *
+     * @access    private
+     * @since     1.7.4
+     *
+     * @return    string
+     */
+    public function _section_deprecation() {
+	    $class = ' notice-error';
+	    $message = __( 'Warning: The Envato Toolkit plugin is no longer supported and will stop functioning very shortly. Please delete the Envato Toolkit plugin and install the new Envato Market plugin.', 'sample-text-domain' );
+
+	    printf( '<div class="%1$s" style="background: #fff; border-left: 4px solid #fff; box-shadow: 0 1px 1px 0 rgba(0,0,0,.1); margin: 5px 15px 2px; padding: 1px 12px;     border-left-color: #dc3232;"><p>%2$s <a href="https://envato.com/market-plugin/upgrading/" target="_blank">Click here for more details.</a></p></div>', esc_attr( $class ), esc_html( $message ) );
+    }
+
     /**
      * User account description
      *
@@ -753,7 +782,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
     public function _section_user_account_info() {
       _e( 'To obtain your API Key, visit your "My Settings" page on any of the Envato Marketplaces. Once a valid connection has been made any changes to the API key below for this username will not effect the results for 5 minutes because they\'re cached in the database. If you have already made an API connection and just purchase a theme and it\'s not showing up, wait five minutes and refresh the page. If the theme is still not showing up, it\'s possible the author has not made it available for auto install yet.', 'envato-wordpress-toolkit' );
     }
-    
+
     /**
      * Username text field
      *
@@ -766,7 +795,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       $options = get_option( EWPT_PLUGIN_SLUG );
       echo '<input type="text" class="regular-text" name="' . EWPT_PLUGIN_SLUG . '[user_name]" value="' . esc_attr( $options['user_name'] ) . '" autocomplete="off" />';
     }
-    
+
     /**
      * API Key text field
      *
@@ -779,7 +808,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       $options = get_option( EWPT_PLUGIN_SLUG );
       echo '<input type="password" class="regular-text" name="' . EWPT_PLUGIN_SLUG . '[api_key]" value="' . esc_attr( $options['api_key'] ) . '" autocomplete="off" />';
     }
-    
+
     /**
      * Backup description
      *
@@ -791,7 +820,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
     public function _section_backup_information() {
       _e( 'This plugin will automatically save your theme as a ZIP archive before it does an upgrade. The directory those backups get saved to is <code>wp-content/envato-backups</code>. However, if you\'re experiencing problems while attempting to upgrade, it\'s likely to be a permissions issue and you may want to manually backup your theme before upgrading. Alternatively, if you don\'t want to backup your theme you can check the box below.', 'envato-wordpress-toolkit' );
     }
-    
+
     /**
      * No theme backup
      *
@@ -805,7 +834,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       $field_value = isset( $options['skip_theme_backup'] ) ? true : false;
       echo '<input type="checkbox" name="' . EWPT_PLUGIN_SLUG . '[skip_theme_backup]" value="1" ' . checked( $field_value, 1, false ) . ' />';
     }
-    
+
     /**
      * Github Updater
      *
@@ -817,7 +846,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
     public function _section_github_updater() {
       printf( __( 'This option lets you deactivate the %s class, so it does not load. If you want to update the plugin in the future, just uncheck this option and the plugin will look for a new version on Github; check it and it stops looking.', 'envato-wordpress-toolkit' ), '<code>WP_GitHub_Updater</code>' );
     }
-    
+
     /**
      * Deactivate Github Updater
      *
@@ -878,8 +907,8 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       }
       return $actions;
     }
-    
-    
+
+
     /**
      * Manually installs a theme from the Envato API.
      *
@@ -893,12 +922,12 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      */
     protected function _install_theme( $theme, $themes ) {
       global $current_screen;
-      
+
       check_admin_referer( 'install-theme_' . $theme );
-      
+
       if ( ! current_user_can( 'install_themes' ) )
         wp_die( __( 'You do not have sufficient permissions to install themes for this site.', 'envato-wordpress-toolkit' ) );
-      
+
       /* setup theme info in $api array */
       $api = (object) array();
       foreach( $themes as $t ) {
@@ -908,22 +937,22 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
           continue;
         }
       }
-      
+
       $title = sprintf( __( 'Installing Theme: %s', 'envato-wordpress-toolkit' ), $api->name . ' ' . $api->version );
       $nonce = 'install-theme_' . $theme;
       $url = network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&action=install-theme&theme=' . $theme );
       $type = 'web';
-      
+
       /* trick WP into thinking it's the themes page for the icon32 */
       $current_screen->parent_base = 'themes';
-      
+
       /* new Envato_Theme_Upgrader */
       $upgrader = new Envato_Theme_Upgrader( new Theme_Installer_Skin( compact( 'title', 'url', 'api', 'nonce' ) ) );
-      
+
       /* install the theme */
       $upgrader->install( $this->protected_api->wp_download( $theme ) );
     }
-    
+
     /**
      * Activate an Envato theme
      *
@@ -936,18 +965,18 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      */
     protected function _activate_theme( $template, $stylesheet ) {
       check_admin_referer( 'switch-theme_' . $template );
-      
+
       if ( ! current_user_can( 'switch_themes' ) && ! current_user_can( 'edit_theme_options' ) )
         wp_die( __( 'You do not have sufficient permissions to update themes for this site.', 'envato-wordpress-toolkit' ) );
-      
+
       if ( ! function_exists( 'switch_theme' ) )
         include_once( ABSPATH . 'wp-admin/includes/theme.php' );
-        
+
       switch_theme( $template, $stylesheet );
       wp_redirect( network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&activated=true&tab=themes' ) );
       exit;
     }
-    
+
     /**
      * Manually upgrades a theme from the Envato API.
      *
@@ -961,30 +990,30 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      */
     protected function _upgrade_theme( $theme, $item_id ) {
       global $current_screen;
-      
+
       check_admin_referer( 'upgrade-theme_' . $theme );
-      
+
       if ( ! current_user_can( 'update_themes' ) )
         wp_die( __( 'You do not have sufficient permissions to update themes for this site.', 'envato-wordpress-toolkit' ) );
-      
+
       $title = __( 'Update Theme', 'envato-wordpress-toolkit' );
       $nonce = 'upgrade-theme_' . $theme;
       $url = network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&action=upgrade-theme&tab=themes&theme=' . $theme . '&item_id=' . $item_id );
-      
+
       /* trick WP into thinking it's the themes page for the icon32 */
       $current_screen->parent_base = 'themes';
-      
+
       /* Upgrade Theme if a backup is created first */
       $options = get_option( EWPT_PLUGIN_SLUG );
       if ( isset( $options['skip_theme_backup'] ) || $this->_backup_theme( $theme ) === true ) {
         /* new Envato_Theme_Upgrader */
         $upgrader = new Envato_Theme_Upgrader( new Theme_Upgrader_Skin( compact( 'title', 'nonce', 'url', 'theme' ) ) );
-        
+
         /* upgrade the theme */
         $upgrader->upgrade( $theme, $this->protected_api->wp_download( $item_id ) );
       }
     }
-    
+
     /**
      * Delete an Envato theme
      *
@@ -996,21 +1025,21 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      */
     protected function _delete_theme( $template ) {
       check_admin_referer( 'delete-theme_' . $template );
-  
+
       if ( ! current_user_can( 'switch_themes' ) && ! current_user_can( 'edit_theme_options' ) )
         wp_die( __( 'You do not have sufficient permissions to update themes for this site.', 'envato-wordpress-toolkit' ) );
-      
+
       if ( ! current_user_can( 'delete_themes' ) )
         wp_die( __( 'You do not have sufficient permissions to delete themes for this site.', 'envato-wordpress-toolkit' ) );
-      
+
       if ( ! function_exists( 'delete_theme' ) )
         include_once( ABSPATH . 'wp-admin/includes/theme.php' );
-      
+
       delete_theme( $template, wp_nonce_url( network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&action=delete&template=' . $template ), 'delete-theme_' . $template ) );
       wp_redirect( network_admin_url( 'admin.php?page=' . EWPT_PLUGIN_SLUG . '&deleted=true&tab=themes' ) );
       exit;
     }
-  
+
     /**
      * Backup an Envato theme.
      *
@@ -1024,36 +1053,36 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    void
      */
     protected function _backup_theme( $theme ) {
-      
+
       $backup_errors = array();
-      
+
       $theme_backup = Envato_Backup::get_instance();
-      
+
       $theme_backup->path = EWPT_BACKUP_DIR;
-      
+
       $theme_backup->root = get_theme_root() . '/' . $theme . '/';
-      
+
       $theme_backup->archive_filename = strtolower( sanitize_file_name( $theme . '.backup.' . date( 'Y-m-d-H-i-s', time() + ( current_time( 'timestamp' ) - time() ) ) . '.zip' ) );
-      
+
       if ( ( ! is_dir( $theme_backup->path() ) && ( ! is_writable( dirname( $theme_backup->path() ) ) || ! mkdir( $theme_backup->path() ) ) ) || ! is_writable( $theme_backup->path() ) ) {
         array_push( $backup_errors, 'Invalid backup path' );
         return false;
       }
-      
+
       if ( ! is_dir( $theme_backup->root() ) || ! is_readable( $theme_backup->root() ) ) {
         array_push( $backup_errors, 'Invalid root path' );
         return false;
       }
-      
+
       $theme_backup->backup();
-      
+
       if ( file_exists( Envato_Backup::get_instance()->archive_filepath() ) ) {
         return true;
       } else {
         return $backup_errors;
       }
     }
-    
+
     /**
      * Prepare the envato backup directory and .htaccess
      *
@@ -1063,16 +1092,16 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    void
      */
     function _prepare_envato_backup() {
-      
+
       $path = EWPT_BACKUP_DIR;
-      
+
       /* Create the backups directory if it doesn't exist */
       if ( is_writable( dirname( $path ) ) && ! is_dir( $path ) )
         mkdir( $path, 0755 );
-      
+
       /* Secure the directory with a .htaccess file */
       $htaccess = $path . '.htaccess';
-      
+
       $contents[]  = '# ' . __( 'This .htaccess file ensures that other people cannot download your backup files.', 'envato-wordpress-toolkit' );
       $contents[] = '';
       $contents[] = '<IfModule mod_rewrite.c>';
@@ -1081,12 +1110,12 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       $contents[] = 'RewriteRule (.*) - [F]';
       $contents[] = '</IfModule>';
       $contents[] = '';
-      
+
       if ( ! file_exists( $htaccess ) && is_writable( $path ) && require_once( ABSPATH . '/wp-admin/includes/misc.php' ) )
         insert_with_markers( $htaccess, 'EnvatoBackup', $contents );
-  
+
     }
-  
+
     /**
      * Get the backup directory path for a given theme.
      *
@@ -1097,9 +1126,9 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    bool|string   Return the theme path or false.
      */
     protected function _get_theme_backup_dir( $theme ) {
-    
+
       $backup_path = EWPT_BACKUP_DIR;
-      
+
       if ( $handle = @opendir( $backup_path ) ) {
         $files = array();
         while ( false !== ( $file = readdir( $handle ) ) ) {
@@ -1111,13 +1140,13 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
         closedir( $handle );
         krsort( $files );
       }
-      
+
       if ( isset( $files ) && ! empty( $files ) )
         return array_shift( $files );
-      
+
       return false;
     }
-    
+
     /**
      * Get the backup directory URI for a given theme.
      *
@@ -1130,24 +1159,24 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @return    bool|string Return the theme URI or false.
      */
     protected function _get_theme_backup_uri( $theme ) {
-    
+
       $theme_backup = $this->_get_theme_backup_dir( $theme );
-      
+
       if ( empty( $theme_backup ) )
         return false;
-      
+
       $theme_backup_uri = str_replace( EWPT_BACKUP_DIR, EWPT_BACKUP_URL, $theme_backup );
-      
+
       if ( defined( 'EWPT_SECURE_KEY' ) ) {
         $theme_backup_uri = $theme_backup_uri . '?key=' . md5( EWPT_SECURE_KEY );
       }
-      
+
       if ( '' != $theme_backup_uri )
         return $theme_backup_uri;
-      
+
       return false;
     }
-    
+
     /**
      * Force PHP to extend max_execution_time to ensure larger themes can download
      *
@@ -1170,10 +1199,10 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
         }
         $r['timeout'] = EWPT_PLUGIN_MAX_EXECUTION_TIME;
       }
-      
+
       return $r;
     }
-  
+
     /**
      * Attempt to force increase to max_execution_time, throw exception with user-friendly message otherwise
      *
@@ -1187,7 +1216,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
         throw new Exception( 'Unable to increase maximum execution time. Due to settings on your server, large themes may be unable to update automatically. Please consult your server administrator if this causes issues for you.' );
       }
     }
-  
+
     /**
      * Ajax method for hiding dismissable admin notices.
      * Forked from original code by Tom McFarlin.
@@ -1198,27 +1227,27 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * @since     1.6.1
      */
     public function _hide_admin_notification() {
-  
+
       if( wp_verify_nonce( $_REQUEST['nonce'], 'ajax-notification-nonce' ) && ! empty( $_REQUEST['notice_id'] ) ) {
-  
+
         $options = get_option( EWPT_PLUGIN_SLUG );
-  
+
         // If the update to the option is successful, send 1 back to the browser;
         // Otherwise, send 0.
         $options['dismissed_errors'][$_REQUEST['notice_id']] = 1;
-  
+
         if ( update_option( EWPT_PLUGIN_SLUG, $options ) ) {
           die( '1' );
         } else {
           die( '0' );
         } // end if/else
-        
+
       } // end if
-  
+
     }
-    
+
   }
-  
+
   /**
    * Instantiates the Class
    *

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Plugin Name: Envato WordPress Toolkit (Deprecated)
  * Plugin URI: https://github.com/envato/envato-wordpress-toolkit
  * Description: WordPress toolkit for Envato Marketplace hosted items. Currently supports the following theme functionality: install, upgrade, & backups during upgrade.
- * Version: 1.7.4
+ * Version: 1.8.0
  * Author: Envato
  * Author URI: http://envato.com
  */
@@ -62,7 +62,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
       /**
        * Plugin Version
        */
-      define( 'EWPT_PLUGIN_VER', '1.7.4' );
+      define( 'EWPT_PLUGIN_VER', '1.8.0' );
 
       /**
        * Plugin Name
@@ -189,7 +189,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
 	  /**
 	   * Adds the deprecation admin notice.
 	   *
-	   * @since 1.7.4
+	   * @since 1.8.0
 	   */
     public function _deprecation_notice(){
 	    $class = 'notice notice-error';
@@ -760,7 +760,7 @@ if ( ! class_exists( 'Envato_WP_Toolkit' ) ) {
      * Deprecation notice on settings page.
      *
      * @access    private
-     * @since     1.7.4
+     * @since     1.8.0
      *
      * @return    string
      */

--- a/readme.txt
+++ b/readme.txt
@@ -8,8 +8,8 @@ bugfixes or support for this version.
 Contributors: envato, valendesigns
 Tags: install, update, api, envato, theme, upgrade
 Requires at least: 3.7
-Tested up to: 4.5
-Stable tag: 1.7.3
+Tested up to: 4.9.5
+Stable tag: 1.7.4
 
 WordPress toolkit for Envato Marketplace hosted items. Currently supports the following theme functionality: install, upgrade, & backups during upgrade.
 
@@ -37,6 +37,9 @@ Below is a description of the new api-key protected Envato Marketplace API metho
 4. Once the API connection has been established you will see a list of themes that can be auto installed. If you don't see any themes and are certain you've done everything correct, there is a good chance the theme author has not updated their theme to be available for auto install and update. If that's the case, please contact the theme author and ask them to update their theme's information.
 
 == Changelog ==
+
+= 1.7.4 =
+* Added deprecation notice as this plugin will soon stop working.
 
 = 1.7.3 =
 * Added a custom user agent to all API requests so a connection is once again possible.

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Contributors: envato, valendesigns
 Tags: install, update, api, envato, theme, upgrade
 Requires at least: 3.7
 Tested up to: 4.9.5
-Stable tag: 1.7.4
+Stable tag: 1.8.0
 
 WordPress toolkit for Envato Marketplace hosted items. Currently supports the following theme functionality: install, upgrade, & backups during upgrade.
 
@@ -38,7 +38,7 @@ Below is a description of the new api-key protected Envato Marketplace API metho
 
 == Changelog ==
 
-= 1.7.4 =
+= 1.8.0 =
 * Added deprecation notice as this plugin will soon stop working.
 
 = 1.7.3 =


### PR DESCRIPTION
Hi Authors,

It will soon be time to shut down the `Envato Toolkit` plugin. We're encouraging authors to remove this plugin from their themes and replace it with the newer `Envato Market` plugin before it stops working.

Back in [in 2015](https://forums.envato.com/t/important-changes-to-our-api/7891) we announced that the old `marketplace.envato.com` API endpoint was to be removed. The Envato Toolkit plugin makes use of this old API endpoint and so the plugin will stop working completely once the API is disabled. We also  launched the new [Envato Market WordPress plugin](https://envato.com/market-plugin/) which is a suitable replacement for the Envato Toolkit plugin. 

It has been great to see all the authors who have swapped from Toolkit to Market, but there are still a few remaining.

We are encouraging authors to check two things:

 - remove the Toolkit plugin from their theme ZIP files or TGM activation parameters, and replace it with the Envato Market plugin.
 - search their theme code for `marketplace.envato.com` to ensure the old API isn't used anywhere else.

Customers who still have the Toolkit plugin installed will soon see an update notification like this:

![image](https://user-images.githubusercontent.com/543073/38399648-df57af94-398e-11e8-90b0-5880beea366f.png)

Once updated, a warning notice will appear within the WordPress dashboard. This is to encourage people to upgrade before the plugin stops working completely:

![image](https://user-images.githubusercontent.com/543073/38285719-d5879e56-3804-11e8-9376-b6f814cefdbc.png)

This notice will link people to http://envato.com/market-plugin/upgrading/ which has some instructions for updating the plugin.